### PR TITLE
feat: Add paste functionality for external clipboard content

### DIFF
--- a/src/TodoApp.js
+++ b/src/TodoApp.js
@@ -830,9 +830,18 @@ class TodoApp {
     }
 
     pasteClipboardTodos() {
-        const newTodos = this.clipboardManager.pasteTodos(this.currentListId, () => this.generateId());
+        // まず内部クリップボードからの貼り付けを試行
+        let newTodos = this.clipboardManager.pasteTodos(this.currentListId, () => this.generateId());
         
-        if (newTodos.length === 0) return;
+        // 内部クリップボードが空の場合、システムクリップボードから読み取り
+        if (newTodos.length === 0) {
+            newTodos = this.clipboardManager.pasteFromSystemClipboard(this.currentListId, () => this.generateId());
+        }
+
+        if (newTodos.length === 0) {
+            console.log('貼り付け可能なコンテンツがありません');
+            return;
+        }
 
         // TodoAppの配列に追加
         newTodos.forEach(todo => this.todos.push(todo));


### PR DESCRIPTION
Implements the requested feature to paste content copied from outside the app.

## Changes
- Enhanced ClipboardManager with system clipboard reading capabilities
- Added intelligent text parsing for various formats
- Modified existing Cmd+V shortcut to handle external content
- Maintains backward compatibility with internal clipboard functionality

## Related Issue
Closes #2

Generated with [Claude Code](https://claude.ai/code)